### PR TITLE
[Feature] Forget vehicle on given time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vehicle-data.json

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,8 +1,8 @@
 RegisterNetEvent('persistent-vehicles/register-vehicle')
-AddEventHandler('persistent-vehicles/register-vehicle', function (entity, light)
+AddEventHandler('persistent-vehicles/register-vehicle', function (entity, light, forgetOn)
 	Wait(0)
 	local props = _Utils.GetVehicleProperties(entity, light)
-	TriggerServerEvent('persistent-vehicles/server/register-vehicle', NetworkGetNetworkIdFromEntity(entity), props)
+	TriggerServerEvent('persistent-vehicles/server/register-vehicle', NetworkGetNetworkIdFromEntity(entity), props, forgetOn)
 end)
 
 RegisterNetEvent('persistent-vehicles/update-vehicle')


### PR DESCRIPTION
## Description
The feature that this PR proposes introduces, gives the developer a way to specify a vehicle forgetting time at registration time.

## Motivation and Context
One of the strongest reasons to add this feature, is to give the developer the possibility to decouple from the context of persisting vehicles and to be able to not worry about the time a vehicle will be registered if an `forget event` is not sent.

This also gives the developer a way to control the performance of the script based on their resources without the need of adding new scripts to handle this logic.

Its not another´s module bussiness to perform checks to forget vehicles, only for some really specific cases.
Ideally they will just need to worry about registering a vehicle on spawns / Forgetting a vehicle when its destroyed / stored into a "garage"

## How Has This Been Tested?
Tested with jb_eden_garages.
Tested with standalone scripts.
Tested with custom fw.
Tested with esx.

**ESX Example:**
```
ESX.Game.SpawnVehicle = function(modelName, coords, heading, cb)
...
local forgetOn = 3 * 60 * 1000 -- 3 minutes test.
TriggerEvent('persistent-vehicles/register-vehicle', vehicle, false, forgetOn)
...
end
```
**OS**: 

- [x] Ubuntu. FXServer 2784
- [x] Windows. FXServer 2784

**Testing the script**
1. Spawn car.
2. Reconnect.
3. Car should still be there (you've 3 minutes for the test to forget it)
4. Logout.
5. Wait the enough time and reconnect. 
6. It should've forget the vehicle properly and the vehicle should not be there anymore.
7. Log the registered vehicles list to confirm its empty. 

The changes follow OCP and doesn't break backwards since its an optional argument.
Its not tested with more than 1 player, but I assume its safe to say it will work properly.
Pretty much since the only changes it adds are 2 checks and 1 action.

## Types of changes
- [x] Add a **forgetOn** argument to the client's register vehicle event.
- [x] Add a **forgetOn** argument to the server's register vehicle event.
- [x] Add a **forgetOn** argument to the server's RegisterVehicle method.
- [x] Add a check in the server's RegisterVehicle method to calculate the forgetAt time if the forgetOn argument is present.
- [x] Add a check in the server's PV:TriggerSpawnEvents method to forget the vehicle if the forgetAt parameter is set on the vehicle metadata and the current time is higher than the forgetAt parameter.
